### PR TITLE
Add GitHub Actions workflow for coverage reports

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,27 @@
+name: Coverage Report
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Install dependencies
+        run: npm install
+      - name: Run coverage report
+        run: npm run fecov_coverage
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-reports
+          path: reports/


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the generation and uploading of coverage reports for the repository. This will help ensure code quality by making coverage data easily available after each push to the `main` branch and on manual workflow dispatch.

Continuous integration and coverage reporting:

* Added a new workflow file, `.github/workflows/coverage.yml`, to automate running coverage reports and uploading results as artifacts on pushes to `main` and on manual triggers.Introduces a workflow to generate and upload coverage reports on pushes to the main branch and manual dispatch. The workflow sets up Node.js, installs dependencies, runs the coverage script, and uploads the results as artifacts.